### PR TITLE
Handle date fields with a `value` as ISO8601 datetime

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "module": "dist/ho-react-components.module.js",
   "scripts": {
     "lint": "eslint .",
-    "pretest": "npm run build",
-    "test": "npm run lint",
+    "pretest:unit-built": "npm run build",
+    "test": "npm run lint && npm run test:unit",
+    "test:unit": "npm run test:unit-built && npm run test:unit-source",
     "test:unit-built": "jest --config ./scripts/jest/config.build.js --env=jsdom",
     "test:unit-source": "jest --config ./scripts/jest/config.source.js --env=jsdom",
     "test:watch": "npm run test:unit-source -- --watch",

--- a/src/forms/__tests__/date.spec.js
+++ b/src/forms/__tests__/date.spec.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { render } from 'enzyme'
+import { DateInput } from 'ho-react-components';
+
+describe('DateInput', () => {
+
+  it('should render three input fields', () => {
+    const rendered = render(<DateInput label="test" name="date" />);
+    expect(rendered.find('input').length).toEqual(3);
+    expect(rendered.find('input[name="date-day"]').length).toEqual(1);
+    expect(rendered.find('input[name="date-month"]').length).toEqual(1);
+    expect(rendered.find('input[name="date-day"]').length).toEqual(1);
+  });
+
+  it('populates fields with date provided as `value`', () => {
+    const rendered = render(<DateInput label="test" name="date" value="2017-06-28" />);
+    expect(rendered.find('input[name="date-day"]').attr('value')).toEqual('28');
+    expect(rendered.find('input[name="date-month"]').attr('value')).toEqual('06');
+    expect(rendered.find('input[name="date-year"]').attr('value')).toEqual('2017');
+  });
+
+  it('populates fields with a full ISO8601 date provided as `value`', () => {
+    const rendered = render(<DateInput label="test" name="date" value="2017-06-28T17:53:12.456Z" />);
+    expect(rendered.find('input[name="date-day"]').attr('value')).toEqual('28');
+    expect(rendered.find('input[name="date-month"]').attr('value')).toEqual('06');
+    expect(rendered.find('input[name="date-year"]').attr('value')).toEqual('2017');
+  });
+
+});

--- a/src/forms/date.jsx
+++ b/src/forms/date.jsx
@@ -10,7 +10,8 @@ class DateInput extends Input {
   }
 
   parseValue() {
-    const bits = this.props.value.split('-');
+    const date = this.props.value.split('T')[0];
+    const bits = date.split('-');
     return {
       day: bits[2],
       month: bits[1],

--- a/src/types/date.js
+++ b/src/types/date.js
@@ -1,5 +1,5 @@
 const date = (props, name, component) => {
-  if (props[name] && !/^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}$/.test(props[name])) {
+  if (props[name] && !/^[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}(T.*)?$/.test(props[name])) {
     return new Error(
       'Invalid prop `' + name + '` supplied to' +
       ' `' + component + '`. Not a valid date (YYYY-MM-DD).'


### PR DESCRIPTION
If a fully qualified datetime string is provided to the date field it should still be able to handle the value without freaking out.