### PR TITLE
Don't attempt to render markdown if React elements passed

### DIFF
--- a/src/forms/input.jsx
+++ b/src/forms/input.jsx
@@ -28,6 +28,9 @@ class Input extends React.Component {
     if (!this.props[type]) {
       return null;
     }
+    if (React.isValidElement(this.props[type])) {
+      return this.props[type];
+    }
     return (
       <span id={`${this.id()}-${type}`} className={className || `govuk-${type}`}>
         <ReactMarkdown>{this.props[type]}</ReactMarkdown>


### PR DESCRIPTION
If a React element is passed as a hint or error message to a form input then don't attempt to Markdown render it. Instead simply return the element.

Currently if a component (in particular a `<Snippet/>`) is passed as an error message or hint then it is not rendered at all and ReactMarkdown throws a warning about non-string props.