### PR TITLE
Use correct govuk-prefixed classes for error messages

### DIFF
--- a/src/forms/checkbox-group.jsx
+++ b/src/forms/checkbox-group.jsx
@@ -35,7 +35,7 @@ class CheckboxGroup extends MultipleChoice(Input) {
           this.getContentPart('hint')
         }
         {
-          this.getContentPart('error', 'error-message')
+          this.getContentPart('error', 'govuk-error-message')
         }
         <div className="govuk-checkboxes">
           {

--- a/src/forms/date.jsx
+++ b/src/forms/date.jsx
@@ -30,7 +30,7 @@ class DateInput extends Input {
           this.getContentPart('hint')
         }
         {
-          this.getContentPart('error', 'error-message')
+          this.getContentPart('error', 'govuk-error-message')
         }
         <div className="govuk-date-input">
           <div className="govuk-date-input__item">

--- a/src/forms/input-text.jsx
+++ b/src/forms/input-text.jsx
@@ -11,7 +11,7 @@ class TextInput extends Input {
         this.getContentPart('hint')
       }
       {
-        this.getContentPart('error', 'error-message')
+        this.getContentPart('error', 'govuk-error-message')
       }
       <input
         className={this.errorClass('govuk-input')}

--- a/src/forms/radio-group.jsx
+++ b/src/forms/radio-group.jsx
@@ -45,7 +45,7 @@ class RadioGroup extends MultipleChoice(Input) {
           this.getContentPart('hint')
         }
         {
-          this.getContentPart('error', 'error-message')
+          this.getContentPart('error', 'govuk-error-message')
         }
         <div className="govuk-radios">
           {

--- a/src/forms/select.jsx
+++ b/src/forms/select.jsx
@@ -15,7 +15,7 @@ class Select extends MultipleChoice(Input) {
         this.getContentPart('hint')
       }
       {
-        this.getContentPart('error', 'error-message')
+        this.getContentPart('error', 'govuk-error-message')
       }
       <select
         className={this.errorClass('govuk-select')}

--- a/src/forms/textarea.jsx
+++ b/src/forms/textarea.jsx
@@ -14,7 +14,7 @@ class TextArea extends Input {
         this.getContentPart('hint')
       }
       {
-        this.getContentPart('error', 'error-message')
+        this.getContentPart('error', 'govuk-error-message')
       }
       <textarea
         className={this.errorClass('govuk-textarea')}


### PR DESCRIPTION
This prefix was lost in https://github.com/UKHomeOffice/react-components/commit/43d5efb2d382fbe33bb0128ef6c30f6ccfa6dbef - put it back