### PR TITLE
Handle null value prop

### DIFF
--- a/src/forms/date.jsx
+++ b/src/forms/date.jsx
@@ -25,7 +25,7 @@ class DateInput extends Input {
   }
 
   parseValue() {
-    const date = this.props.value.split('T')[0];
+    const date = (this.props.value || '').split('T')[0];
     const bits = date.split('-');
     return {
       day: bits[2],


### PR DESCRIPTION
Passing a null `value` prop throws an error. Not sure why the `defaultProps` isn't working as expected, but this makes abslutely certain that it's handled correctly.