### PR TITLE
Prevent `dispatch` prop being set on textarea

### DIFF
--- a/src/forms/textarea.jsx
+++ b/src/forms/textarea.jsx
@@ -32,7 +32,7 @@ class TextArea extends Input {
         cols={cols}
         disabled={disabled}
         readOnly={readonly}
-        {...omit(other, 'maxHeight')}
+        {...omit(other, 'maxHeight', 'dispatch')}
         {...this.checkedOrUnchecked()}
         onInput={autoExpand ? this.onInput.bind(this) : null}
       />


### PR DESCRIPTION
This causes a warning to be logged out to the console for an invalid prop, which makes a lot of noise in the logs. Prevent it.