### PR TITLE
Fix reveals in checkbox groups

### DIFF
--- a/src/forms/__tests__/checkbox-group.spec.js
+++ b/src/forms/__tests__/checkbox-group.spec.js
@@ -1,0 +1,89 @@
+import React from 'react'
+import { render } from 'enzyme'
+import { CheckboxGroup } from 'ho-react-components';
+
+describe('CheckboxGroup', () => {
+
+  it('renders checkboxes', () => {
+    const options = [
+      {
+        label: 'one',
+        value: 1
+      },
+      {
+        label: 'two',
+        value: 2
+      },
+      {
+        label: 'three',
+        value: 3,
+        reveal: <p className="revealed">Hello</p>
+      }
+    ];
+    const rendered = render(<CheckboxGroup
+      label="test"
+      name="date"
+      options={options}
+      value={[ 1, 2 ]}
+    />);
+    expect(rendered.find('input[type="checkbox"]').length).toEqual(3);
+    expect(rendered.find('input[checked]').length).toEqual(2);
+    expect(rendered.find('input[checked]').eq(0).attr('value')).toEqual('1');
+    expect(rendered.find('input[checked]').eq(1).attr('value')).toEqual('2');
+  });
+
+  it('should not render reveals if `initialHideReveals` is true', () => {
+    const options = [
+      {
+        label: 'one',
+        value: 1
+      },
+      {
+        label: 'two',
+        value: 2
+      },
+      {
+        label: 'three',
+        value: 3,
+        reveal: <p className="revealed">Hello</p>
+      }
+    ];
+    const rendered = render(<CheckboxGroup
+      label="test"
+      name="date"
+      options={options}
+      value={1}
+      initialHideReveals={true}
+    />);
+    expect(rendered.find('.govuk-reveal').length).toEqual(0);
+    expect(rendered.find('p.revealed').length).toEqual(0);
+  });
+
+  it('should render reveals if `initialHideReveals` is false', () => {
+    const options = [
+      {
+        label: 'one',
+        value: 1
+      },
+      {
+        label: 'two',
+        value: 2
+      },
+      {
+        label: 'three',
+        value: 3,
+        reveal: <p className="revealed">Hello</p>
+      }
+    ];
+    const rendered = render(<CheckboxGroup
+      label="test"
+      name="date"
+      options={options}
+      value={1}
+      initialHideReveals={false}
+    />);
+    expect(rendered.find('.govuk-reveal').length).toEqual(1);
+    expect(rendered.find('p.revealed').length).toEqual(1);
+  });
+
+});

--- a/src/forms/__tests__/radio-group.spec.js
+++ b/src/forms/__tests__/radio-group.spec.js
@@ -1,0 +1,88 @@
+import React from 'react'
+import { render } from 'enzyme'
+import { RadioGroup } from 'ho-react-components';
+
+describe('RadioGroup', () => {
+
+  it('renders radio buttons', () => {
+    const options = [
+      {
+        label: 'one',
+        value: 1
+      },
+      {
+        label: 'two',
+        value: 2
+      },
+      {
+        label: 'three',
+        value: 3,
+        reveal: <p className="revealed">Hello</p>
+      }
+    ];
+    const rendered = render(<RadioGroup
+      label="test"
+      name="date"
+      options={options}
+      value={2}
+    />);
+    expect(rendered.find('input[type="radio"]').length).toEqual(3);
+    expect(rendered.find('input[checked]').length).toEqual(1);
+    expect(rendered.find('input[checked]').first().attr('value')).toEqual('2');
+  });
+
+  it('should not render reveals if `initialHideReveals` is true', () => {
+    const options = [
+      {
+        label: 'one',
+        value: 1
+      },
+      {
+        label: 'two',
+        value: 2
+      },
+      {
+        label: 'three',
+        value: 3,
+        reveal: <p className="revealed">Hello</p>
+      }
+    ];
+    const rendered = render(<RadioGroup
+      label="test"
+      name="date"
+      options={options}
+      value={1}
+      initialHideReveals={true}
+    />);
+    expect(rendered.find('.govuk-reveal').length).toEqual(0);
+    expect(rendered.find('p.revealed').length).toEqual(0);
+  });
+
+  it('should render reveals if `initialHideReveals` is false', () => {
+    const options = [
+      {
+        label: 'one',
+        value: 1
+      },
+      {
+        label: 'two',
+        value: 2
+      },
+      {
+        label: 'three',
+        value: 3,
+        reveal: <p className="revealed">Hello</p>
+      }
+    ];
+    const rendered = render(<RadioGroup
+      label="test"
+      name="date"
+      options={options}
+      value={1}
+      initialHideReveals={false}
+    />);
+    expect(rendered.find('.govuk-reveal').length).toEqual(1);
+    expect(rendered.find('p.revealed').length).toEqual(1);
+  });
+
+});

--- a/src/forms/checkbox-group.jsx
+++ b/src/forms/checkbox-group.jsx
@@ -27,13 +27,13 @@ class CheckboxGroup extends MultipleChoice(Input) {
   render() {
     const options = this.normaliseOptions();
 
-    function showReveal(opt) {
+    const showReveal = opt => {
       if (!this.props.initialHideReveals) {
         return true;
       }
 
       return this.hasValue(opt.value);
-    }
+    };
 
     return <div className={this.errorClass('govuk-form-group')}>
       <fieldset id={this.props.id || this.props.name} className={classnames('govuk-fieldset', { inline: this.props.inline }, this.props.className)}>


### PR DESCRIPTION
Declaring the helper function as a `function` and not an arrow function means that references to `this` inside fail, and so any attempt to render a checkbox group with reveals throws an error of `Cannot read property 'props' of undefined`