### PR TITLE
Add unique suffix to checkbox and radio group key/id props

### DIFF
--- a/src/mixins/multiple-choice.js
+++ b/src/mixins/multiple-choice.js
@@ -1,7 +1,8 @@
 export default (superclass) => class MultipleChoice extends superclass {
 
   optionId(opt) {
-    return `${this.id()}-${opt.value.toString().toLowerCase().replace(/[^a-z0-9-]/g, '')}`;
+    const key = opt.value.toString().split('').reduce((str, char) => str + char.charCodeAt(0), '');
+    return `${this.id()}-${opt.value.toString().toLowerCase().replace(/[^a-z0-9-]/g, '')}-${key}`;
   }
 
   hasValue(val) {


### PR DESCRIPTION
The function that generated these props doesn't return unique values where option values differ only by hyphenation or casing.

i.e. the following example values all result in the same key and id, and so cause problems when rendering: `Upper case`, `UPPER CASE`, `Upper-case`

Concatenate the character codes into a unique suffix so that key and id props are always unique for unique values.