### PR TITLE
Allow markdown in radio/checkbox hints

### DIFF
--- a/src/forms/checkbox-group.jsx
+++ b/src/forms/checkbox-group.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import ReactMarkdown from 'react-markdown';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Types from '../types';
@@ -68,7 +69,7 @@ class CheckboxGroup extends MultipleChoice(Input) {
                     {...this.optProps(opt)}
                   />
                   <label htmlFor={this.optionId(opt)} className="govuk-label govuk-checkboxes__label">{opt.label}</label>
-                  { opt.hint && <span className="govuk-hint">{opt.hint}</span> }
+                  { opt.hint && <span className="govuk-hint"><ReactMarkdown>{opt.hint}</ReactMarkdown></span> }
                   {
                     opt.warning &&
                       <div className="govuk-reveal">

--- a/src/forms/radio-group.jsx
+++ b/src/forms/radio-group.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import ReactMarkdown from 'react-markdown';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Types from '../types';
@@ -67,7 +68,7 @@ class RadioGroup extends MultipleChoice(Input) {
                   {...this.optProps(opt)}
                 />
                 <label htmlFor={this.optionId(opt)} className="govuk-label govuk-radios__label">{opt.label}</label>
-                { opt.hint && <span className="govuk-hint">{opt.hint}</span> }
+                { opt.hint && <span className="govuk-hint"><ReactMarkdown>{opt.hint}</ReactMarkdown></span> }
                 {
                   opt.reveal && !this.props.inline && getReveal(opt)
                 }


### PR DESCRIPTION
I can't currently test this as I can't build & link it due to issues with node-sass / python / macos / apple silicon.

This has the potential to break existing hints if they have markdown-like content that shouldn't be rendered as markdown.

Maybe it would be better to have an `opt.markdownHint` or similar instead so that we can opt-in?