### PR TITLE
[ASL-4614] Changes for declaration component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ukhomeoffice/react-components",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ukhomeoffice/react-components",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ukhomeoffice/react-components",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "React components for Home Office layouts and elements",
   "main": "dist/ho-react-components.js",
   "module": "dist/ho-react-components.module.js",

--- a/src/forms/__tests__/checkbox-group.spec.js
+++ b/src/forms/__tests__/checkbox-group.spec.js
@@ -1,29 +1,29 @@
-import React from 'react'
-import { render } from 'enzyme'
+import React from 'react';
+import { render } from 'enzyme';
 import { CheckboxGroup } from 'ho-react-components';
 
+const EXAMPLE_OPTIONS = [
+  {
+    label: 'one',
+    value: 1
+  },
+  {
+    label: 'two',
+    value: 2
+  },
+  {
+    label: 'three',
+    value: 3,
+    reveal: <p className="revealed">Hello</p>
+  }
+];
 describe('CheckboxGroup', () => {
 
   it('renders checkboxes', () => {
-    const options = [
-      {
-        label: 'one',
-        value: 1
-      },
-      {
-        label: 'two',
-        value: 2
-      },
-      {
-        label: 'three',
-        value: 3,
-        reveal: <p className="revealed">Hello</p>
-      }
-    ];
     const rendered = render(<CheckboxGroup
       label="test"
       name="date"
-      options={options}
+      options={EXAMPLE_OPTIONS}
       value={[ 1, 2 ]}
     />);
     expect(rendered.find('input[type="checkbox"]').length).toEqual(3);
@@ -33,25 +33,10 @@ describe('CheckboxGroup', () => {
   });
 
   it('should not render reveals if `initialHideReveals` is true', () => {
-    const options = [
-      {
-        label: 'one',
-        value: 1
-      },
-      {
-        label: 'two',
-        value: 2
-      },
-      {
-        label: 'three',
-        value: 3,
-        reveal: <p className="revealed">Hello</p>
-      }
-    ];
     const rendered = render(<CheckboxGroup
       label="test"
       name="date"
-      options={options}
+      options={EXAMPLE_OPTIONS}
       value={1}
       initialHideReveals={true}
     />);
@@ -60,25 +45,10 @@ describe('CheckboxGroup', () => {
   });
 
   it('should render reveals if `initialHideReveals` is false', () => {
-    const options = [
-      {
-        label: 'one',
-        value: 1
-      },
-      {
-        label: 'two',
-        value: 2
-      },
-      {
-        label: 'three',
-        value: 3,
-        reveal: <p className="revealed">Hello</p>
-      }
-    ];
     const rendered = render(<CheckboxGroup
       label="test"
       name="date"
-      options={options}
+      options={EXAMPLE_OPTIONS}
       value={1}
       initialHideReveals={false}
     />);
@@ -144,6 +114,43 @@ describe('CheckboxGroup', () => {
     />);
     expect(rendered.find('.govuk-checkboxes__divider-wide').length).toEqual(1);
     expect(rendered.find('.govuk-checkboxes__divider-wide').text()).toEqual('Or select each that applies:');
+  })
+
+  it('renders a default hint wrapper', () => {
+    const rendered = render(<CheckboxGroup
+        label="test"
+        name="date"
+        options={[
+          {
+            label: 'one',
+            value: 1,
+            ['aria-describedby']: 'date-hint',
+          }
+        ]}
+        value={1}
+        hint='Hint in a span'
+    />);
+
+    expect(rendered.find('span#date-hint.govuk-hint').text()).toEqual('Hint in a span');
+  })
+
+  it('should render a custom hint wrapper', () => {
+    const rendered = render(<CheckboxGroup
+        label="test"
+        name="date"
+        options={[
+          {
+            label: 'one',
+            value: 1,
+            ['aria-describedby']: 'date-hint',
+          }
+        ]}
+        value={1}
+        hint={<p>Hint in a paragraph</p>}
+        hintWrapper={({id, children}) => <div id={id}>{children}</div>}
+    />);
+
+    expect(rendered.find('div#date-hint > p').text()).toEqual('Hint in a paragraph');
   })
 
 });

--- a/src/forms/input.jsx
+++ b/src/forms/input.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 
+const DefaultWrapper = ({ children, type, className, id }) =>
+    <span id={id} className={className || `govuk-${type}`}>
+        {children}
+    </span>;
+
 class Input extends React.Component {
 
     id() {
@@ -28,14 +33,16 @@ class Input extends React.Component {
         if (!this.props[type]) {
             return null;
         }
+        const Component = this.props[`${type}Wrapper`] ?? DefaultWrapper;
+
         return (
-            <span id={`${this.id()}-${type}`} className={className || `govuk-${type}`}>
+            <Component type={type} className={className} id={`${this.id()}-${type}`}>
                 {
                     React.isValidElement(this.props[type])
                         ? this.props[type]
                         : <ReactMarkdown>{this.props[type]}</ReactMarkdown>
                 }
-            </span>
+            </Component>
         );
     }
 


### PR DESCRIPTION
To support linking the list of declarations to the checkbox we need to include it in the hint slot for the group.

This adds the option to control how we wrap the various content sections for an input to allow this.